### PR TITLE
アバターメタデータファイルのファイル名仕様変更

### DIFF
--- a/Editor/AvatarMetadataEditorWindow/AvatarMetadataEditorWindow.uxml
+++ b/Editor/AvatarMetadataEditorWindow/AvatarMetadataEditorWindow.uxml
@@ -11,8 +11,8 @@
                     <ui:Button name="delete-metadata-button" text="メタデータ削除" />
                 </ui:VisualElement>
             </ui:VisualElement>
-            <ui:HelpBox name="name-difference-warning-message-helpbox" text="アバターオブジェクト名とアバターメタデータのファイル名が一致していません" message-type="warning" style="display: none" />
-            <ui:Button name="sync-filename-button" text="アバターメタデータのファイル名をアバター名に合わせる" style="display: none" />
+            <ui:HelpBox name="warning-message-helpbox" text="このアバターメタデータは別のアバターオブジェクトに設定されている可能性があります" message-type="warning" style="display: none" />
+            <ui:Button name="sync-avatar-global-id-button" text="アバターメタデータを編集対象のアバターオブジェクトへ紐付ける" style="display: none" />
             <ui:Button name="copy-avatar-metadata-file-button" text="アバターメタデータファイルを複製する" style="display: none" />
         </ui:VisualElement>
     </ui:VisualElement>

--- a/Editor/Inspector/UI/AvatarMetadataSettingsEditor.uxml
+++ b/Editor/Inspector/UI/AvatarMetadataSettingsEditor.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
     <uie:ObjectField label="Avatar Metadata" name="avatar-metadata" type="MitarashiDango.AvatarCatalog.Runtime.AvatarMetadata, com.matcha-soft.avatar-catalog.runtime" binding-path="avatarMetadata" />
-    <ui:HelpBox name="name-difference-warning-message-helpbox" text="アバターオブジェクト名とアバターメタデータのファイル名が一致していません" message-type="warning" style="display: none" />
-    <ui:Button name="sync-filename-button" text="アバターメタデータのファイル名をアバター名に合わせる" style="display: none" />
+    <ui:HelpBox name="warning-message-helpbox" text="このアバターメタデータは別のアバターオブジェクトに設定されている可能性があります" message-type="warning" style="display: none" />
+    <ui:Button name="sync-avatar-global-id-button" text="アバターメタデータをこのアバターオブジェクトへ紐付ける" style="display: none" />
     <ui:Button name="copy-avatar-metadata-file-button" text="アバターメタデータファイルを複製する" style="display: none" />
 </ui:UXML>

--- a/Runtime/AvatarMetadata.cs
+++ b/Runtime/AvatarMetadata.cs
@@ -7,6 +7,11 @@ namespace MitarashiDango.AvatarCatalog.Runtime
     public class AvatarMetadata : ScriptableObject
     {
         /// <summary>
+        /// メタデータが紐付いているアバターオブジェクトのグローバルオブジェクトID
+        /// </summary>
+        public string avatarGlobalObjectId = "";
+
+        /// <summary>
         /// コメント
         /// </summary>
         public string comment = "";


### PR DESCRIPTION
#69 の内容を実装

また、仕様変更に伴い、旧形式のマイグレーション処理を削除。
※旧形式 (Avatar Metadata Settingsコンポーネントによる紐付けではなく、ファイル名ベースでの紐付け) からのマイグレーションを行いたい場合、本変更を取り込む前にマイグレーションを行ってから更新を行う必要がある。